### PR TITLE
Remove rJava dependency and fix issue 4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,12 +24,13 @@ Imports:
   dbplyr,
   tidyselect,
   cli,
-  pillar
+  pillar,
+  stringr,
+  rlang
 Suggests:
   testthat,
   knitr,
   rmarkdown,
-  rlang,
   tibble
 LazyData: false
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,9 +30,8 @@ Suggests:
   knitr,
   rmarkdown,
   rlang,
-  tibble,
-  rJava
+  tibble
 LazyData: false
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/R/LoadingSaving.R
+++ b/R/LoadingSaving.R
@@ -53,7 +53,8 @@
 #' @export
 saveAndromeda <- function(andromeda, fileName, maintainConnection = FALSE, overwrite = TRUE) {
   if (!overwrite && file.exists(fileName)) {
-    stop("File ", fileName, " already exists, and overwrite = FALSE")
+    msg <- paste0("File ", fileName, " already exists, and overwrite = FALSE")
+    rlang::abort(msg, class = "Andromeda")
   }
   
   if (!isValidAndromeda(andromeda)) {
@@ -87,7 +88,7 @@ saveAndromeda <- function(andromeda, fileName, maintainConnection = FALSE, overw
     RSQLite::dbDisconnect(andromeda)
     zip::zipr(fileName, c(attributesFileName, andromeda@dbname), compression_level = 2)
     unlink(andromeda@dbname)
-    message("Disconnected Andromeda. This data object can no longer be used")
+    rlang::inform("Disconnected Andromeda. This data object can no longer be used", class = "Andromeda")
   }
   unlink(attributesFileName)
 }
@@ -182,10 +183,8 @@ loadAndromeda <- function(fileName) {
       
       message <- c(message, 
                    pillar::style_subtle("Use options(warnDiskSpaceThreshold = <n>) to set the number of bytes for this warning to trigger."))
-      message <- c(message, 
-                   pillar::style_subtle("This warning will not be shown for this file location again during this R session."))
       
-      warning(paste(message, collapse = "\n"), call. = FALSE) 
+      rlang::warn(paste(message, collapse = "\n"), class = "Andromeda", .frequency = "once", .frequency_id = folder) 
       assign("lowDiskWarnings", c(lowDiskWarnings, folder), envir = andromedaGlobalEnv)
     }
   }
@@ -233,15 +232,13 @@ getAndromedaTempDiskSpace <- function(andromeda = NULL) {
     return(NA)
   }
   
-  osInfo <- tolower(paste(sessionInfo()$platform, sessionInfo()$running))
-  os <- regmatches(osInfo, regexpr("windows|mac|linux", osInfo))
-  if(!(os %in% c("windows", "mac", "linux"))) {
+  if(!(.Platform$OS.type %in% c("windows", "unix"))) {
     msg <- "Operating system cannot be determined.\nCannot get available Andromeda disk space.\n"
     rlang::warn(msg, class = "Andromeda")
     return(NA)
   }
   
-  if (os == "windows") {
+  if (.Platform$OS.type == "windows") {
     # https://stackoverflow.com/questions/32200879/how-to-get-disk-space-of-windows-machine-with-r
     # https://stackoverflow.com/questions/293780/free-space-in-a-cmd-shell
     disks <- system("wmic logicaldisk get size,freespace,caption", inter = T)
@@ -250,7 +247,7 @@ getAndromedaTempDiskSpace <- function(andromeda = NULL) {
                         col.names =  c("disk", "freeSpace", "size"),
                         row.names = NULL)
     
-    idRow <- stringr::str_detect(folder, paste0("^",disks$disk))
+    idRow <- stringr::str_detect(tolower(folder), tolower(paste0("^",disks$disk)))
     if(sum(idRow) != 1) {
       msg <- paste0("Andromeda temp disk cannot be determined.\n",
                     "folder: ", folder, "\n",
@@ -263,10 +260,10 @@ getAndromedaTempDiskSpace <- function(andromeda = NULL) {
     }
   }
   
-  if (os %in% c("linux", "mac")) {
+  if (.Platform$OS.type == "unix") {
     # https://stat.ethz.ch/pipermail/r-help/2007-October/142319.html
-    if(length(system("which dsf", intern = T, ignore.stderr = T)) != 1) {
-      msg <- paste0("`which df` command returned error on ", os, "\n",
+    if(length(system("which df", intern = T, ignore.stderr = T)) != 1) {
+      msg <- paste0("`which df` command returned error\n",
                     "Cannot get available Andromeda disk space.\n")
       rlang::warn(msg, class = "Andromeda")
       return(NA)

--- a/R/LoadingSaving.R
+++ b/R/LoadingSaving.R
@@ -55,6 +55,18 @@ saveAndromeda <- function(andromeda, fileName, maintainConnection = FALSE, overw
   if (!overwrite && file.exists(fileName)) {
     stop("File ", fileName, " already exists, and overwrite = FALSE")
   }
+  
+  if (!isValidAndromeda(andromeda)) {
+    rlang::abort("andromeda object is closed or not valid.")
+  }
+  
+  fileName <- path.expand(fileName)
+  if (!dir.exists(dirname(fileName))) {
+    msg <- paste("The directory", dirname(fileName), "does not exist.\n",
+                 "Andromeda object cannot be saved to ", fileName, ".\n")
+    rlang::abort(msg, class = "Andromeda")
+  }
+  
   # Need to save any user-defined attributes as well:
   attribs <- attributes(andromeda)
   for (name in slotNames(andromeda)) {
@@ -75,7 +87,7 @@ saveAndromeda <- function(andromeda, fileName, maintainConnection = FALSE, overw
     RSQLite::dbDisconnect(andromeda)
     zip::zipr(fileName, c(attributesFileName, andromeda@dbname), compression_level = 2)
     unlink(andromeda@dbname)
-    writeLines("Disconnected Andromeda. This data object can no longer be used")
+    message("Disconnected Andromeda. This data object can no longer be used")
   }
   unlink(attributesFileName)
 }
@@ -143,40 +155,38 @@ loadAndromeda <- function(fileName) {
 }
 
 .checkAvailableSpace <- function(andromeda = NULL) {
-  if (.isInstalled("rJava")) {
-    warnDiskSpace <- getOption("warnDiskSpaceThreshold")
-    if (is.null(warnDiskSpace)) {
-      warnDiskSpace <- 10 * 1024 ^ 3
+  warnDiskSpace <- getOption("warnDiskSpaceThreshold")
+  if (is.null(warnDiskSpace)) {
+    warnDiskSpace <- 10 * 1024 ^ 3
+  }
+  if (warnDiskSpace != 0) {
+    if (is.null(andromeda)) {
+      folder <- .getAndromedaTempFolder()
+    } else {
+      folder <- dirname(andromeda@dbname) 
     }
-    if (warnDiskSpace != 0) {
-      if (is.null(andromeda)) {
-        folder <- .getAndromedaTempFolder()
-      } else {
-        folder <- dirname(andromeda@dbname) 
+    if (exists("lowDiskWarnings", envir = andromedaGlobalEnv)) {
+      lowDiskWarnings <- get("lowDiskWarnings", envir = andromedaGlobalEnv)
+      if (folder %in% lowDiskWarnings) {
+        # Already warned about this location. Not warning again.
+        return()
       }
-      if (exists("lowDiskWarnings", envir = andromedaGlobalEnv)) {
-        lowDiskWarnings <- get("lowDiskWarnings", envir = andromedaGlobalEnv)
-        if (folder %in% lowDiskWarnings) {
-          # Already warned about this location. Not warning again.
-          return()
-        }
-      } else {
-        lowDiskWarnings <- c()
-      }
-      space <- getAndromedaTempDiskSpace(andromeda)
-      if (!is.na(space) && space < warnDiskSpace) {
-        message <- sprintf("Low disk space in '%s'. Only %0.1f GB left.", 
-                           folder, 
-                           space / 1024^3)
-        
-        message <- c(message, 
-                     pillar::style_subtle("Use options(warnDiskSpaceThreshold = <n>) to set the number of bytes for this warning to trigger."))
-        message <- c(message, 
-                     pillar::style_subtle("This warning will not be shown for this file location again during this R session."))
-        
-        warning(paste(message, collapse = "\n"), call. = FALSE) 
-        assign("lowDiskWarnings", c(lowDiskWarnings, folder), envir = andromedaGlobalEnv)
-      }
+    } else {
+      lowDiskWarnings <- c()
+    }
+    space <- getAndromedaTempDiskSpace(andromeda)
+    if (!is.na(space) && space < warnDiskSpace) {
+      message <- sprintf("Low disk space in '%s'. Only %0.1f GB left.", 
+                         folder, 
+                         space / 1024^3)
+      
+      message <- c(message, 
+                   pillar::style_subtle("Use options(warnDiskSpaceThreshold = <n>) to set the number of bytes for this warning to trigger."))
+      message <- c(message, 
+                   pillar::style_subtle("This warning will not be shown for this file location again during this R session."))
+      
+      warning(paste(message, collapse = "\n"), call. = FALSE) 
+      assign("lowDiskWarnings", c(lowDiskWarnings, folder), envir = andromedaGlobalEnv)
     }
   }
 }
@@ -185,7 +195,6 @@ loadAndromeda <- function(fileName) {
 #' 
 #' @description 
 #' Attempts to determine how much disk space is still available in the Andromeda temp folder. 
-#' This function uses Java, so will only work if the `rJava` package is installed.
 #' 
 #' By default the Andromeda temp folder is located in the system temp space, but the location
 #' can be altered using `options(andromedaTempFolder = "c:/andromedaTemp")`, where
@@ -197,9 +206,8 @@ loadAndromeda <- function(fileName) {
 #'
 #' @return
 #' The number of bytes of available disk space in the Andromeda temp folder. Returns NA
-#' if unable to determine the amount of available disk space, for example because `rJava` 
-#' is not installed, or because the user doesn't have the rights to query the available 
-#' disk space.
+#' if unable to determine the amount of available disk space, for example because
+#' because the user doesn't have the rights to query the available disk space.
 #'
 #' @examples
 #' # Get the number of available gigabytes:
@@ -211,27 +219,64 @@ getAndromedaTempDiskSpace <- function(andromeda = NULL) {
   if (!is.null(andromeda) && !inherits(andromeda, "SQLiteConnection")) 
     stop("Andromeda argument must be of type 'Andromeda'.")
   
-  # Using Java because no cross-platform functions available in R:
-  if (!.isInstalled("rJava")) {
-    return(NA)
+  if (is.null(andromeda)) {
+    folder <- .getAndromedaTempFolder()
   } else {
-    if (is.null(andromeda)) {
-      folder <- .getAndromedaTempFolder()
-    } else {
-      folder <- dirname(andromeda@dbname) 
-    }
-    space <- tryCatch({
-      rJava::.jinit()
-      file <- rJava::.jnew("java.io.File", folder, check = FALSE, silent = TRUE)
-      rJava::.jcall(file, "J", "getUsableSpace")
-      
-      # This throws "illegal reflective access operation" warning:
-      # path <- rJava::J("java.nio.file.Paths")$get(fileName, rJava::.jarray(c("")))
-      # fileStore <- rJava::J("java.nio.file.Files")$getFileStore(path)
-      # fileStore$getUsableSpace()
-    }, error = function(e) NA)
-    return(space)
+    folder <- dirname(andromeda@dbname) 
   }
+  
+  if(!dir.exists(folder)) {
+    msg <- paste("Andromeda temp folder does not exist\n",
+                 "folder:", folder, "\n",
+                 "Cannot determine available Andromeda disk space.")
+    rlang::warn(msg, class = "Andromeda")
+    return(NA)
+  }
+  
+  osInfo <- tolower(paste(sessionInfo()$platform, sessionInfo()$running))
+  os <- regmatches(osInfo, regexpr("windows|mac|linux", osInfo))
+  if(!(os %in% c("windows", "mac", "linux"))) {
+    msg <- "Operating system cannot be determined.\nCannot get available Andromeda disk space.\n"
+    rlang::warn(msg, class = "Andromeda")
+    return(NA)
+  }
+  
+  if (os == "windows") {
+    # https://stackoverflow.com/questions/32200879/how-to-get-disk-space-of-windows-machine-with-r
+    # https://stackoverflow.com/questions/293780/free-space-in-a-cmd-shell
+    disks <- system("wmic logicaldisk get size,freespace,caption", inter = T)
+    disks <- read.table(textConnection(disks), 
+                        skip = 1,
+                        col.names =  c("disk", "freeSpace", "size"),
+                        row.names = NULL)
+    
+    idRow <- stringr::str_detect(folder, paste0("^",disks$disk))
+    if(sum(idRow) != 1) {
+      msg <- paste0("Andromeda temp disk cannot be determined.\n",
+                    "folder: ", folder, "\n",
+                    "disks: ", paste(disks$disk, collapse = ", "), "\n",
+                    "Cannot get available Andromeda disk space.\n")
+      rlang::warn(msg, class = "Andromeda")
+      return(NA)
+    } else {
+      space <- disks[idRow,]$freeSpace
+    }
+  }
+  
+  if (os %in% c("linux", "mac")) {
+    # https://stat.ethz.ch/pipermail/r-help/2007-October/142319.html
+    if(length(system("which dsf", intern = T, ignore.stderr = T)) != 1) {
+      msg <- paste0("`which df` command returned error on ", os, "\n",
+                    "Cannot get available Andromeda disk space.\n")
+      rlang::warn(msg, class = "Andromeda")
+      return(NA)
+    } else {
+      stdout <- system(paste("df", folder), intern = T, ignore.stderr = T)
+      space <- as.integer(strsplit(stdout[length(stdout)], "[ ]+")[[1]][4])
+    }
+  }
+  
+  return(space)
 }
 
 .isInstalled <- function(pkg) {

--- a/man/getAndromedaTempDiskSpace.Rd
+++ b/man/getAndromedaTempDiskSpace.Rd
@@ -13,13 +13,11 @@ could have altered it.}
 }
 \value{
 The number of bytes of available disk space in the Andromeda temp folder. Returns NA
-if unable to determine the amount of available disk space, for example because \code{rJava}
-is not installed, or because the user doesn't have the rights to query the available
-disk space.
+if unable to determine the amount of available disk space, for example because
+because the user doesn't have the rights to query the available disk space.
 }
 \description{
 Attempts to determine how much disk space is still available in the Andromeda temp folder.
-This function uses Java, so will only work if the \code{rJava} package is installed.
 
 By default the Andromeda temp folder is located in the system temp space, but the location
 can be altered using \code{options(andromedaTempFolder = "c:/andromedaTemp")}, where

--- a/tests/testthat/test-batching.R
+++ b/tests/testthat/test-batching.R
@@ -43,11 +43,8 @@ test_that("batchApply progress bar", {
   doSomething <- function(batch, multiplier) {
     return(nrow(batch) * multiplier)
   }
-  result <- batchApply(andromeda$cars, doSomething, multiplier = 2, batchSize = 10, progressBar = TRUE)
-  result <- unlist(result)
-  
-  expect_true(sum(result) == nrow(cars) * 2)
-  expect_true(length(result) == ceiling(nrow(cars)/10))
+  result <- capture_output(batchApply(andromeda$cars, doSomething, multiplier = 2, batchSize = 10, progressBar = TRUE))
+  expect_true(stringr::str_count(result, "=") > 100)
   close(andromeda)
 })
 
@@ -66,18 +63,15 @@ test_that("groupApply", {
   close(andromeda)
 })
 
-test_that("groupApply", {
+test_that("groupApply progress bar", {
   andromeda <- andromeda()
   andromeda$cars <- cars
   
   doSomething <- function(batch, multiplier) {
     return(nrow(batch) * multiplier)
   }
-  result <- groupApply(andromeda$cars, "speed", doSomething, multiplier = 2, batchSize = 10, progressBar = TRUE)
-  result <- unlist(result)
-  
-  expect_true(sum(result) == nrow(cars) * 2)
-  expect_true(length(result) == length(unique(cars$speed)))
+  result <- capture_output(groupApply(andromeda$cars, "speed", doSomething, multiplier = 2, batchSize = 10, progressBar = TRUE))
+  expect_true(stringr::str_count(result, "=") > 100)
   close(andromeda)
 })
 


### PR DESCRIPTION
R currently crashes when running saveAndromeda() with a non-existent file path or a path with tildes. 

https://github.com/OHDSI/Andromeda/issues/4

This pull request fixes this issue and removes the dependency on rJava.  It also adds several tests.