### PR TITLE
add test for filelocking issue when using batchApply

### DIFF
--- a/tests/testthat/test-filelocks.R
+++ b/tests/testthat/test-filelocks.R
@@ -1,0 +1,31 @@
+library(testthat)
+
+test_that('Andromeda removes files after batchApply', {
+  fn <- function(df) {
+    df[, 'rowId'] <- NULL
+  }
+  
+  covariates <- data.frame(rowId = rep(1:nrow(infert),2),
+                           covariateId = rep(1:2,each=nrow(infert)),
+                           covariateValue = c(infert$spontaneous,infert$induced))
+  outcomes <- data.frame(rowId = 1:nrow(infert),
+                         y = infert$case)
+  #Make sparse:
+  covariates <- covariates[covariates$covariateValue != 0,]
+  
+  andr <- Andromeda::andromeda(outcomes = outcomes, covariates = covariates)
+  
+  convertData <- function(covariates, outcomes) {
+    outcomeRowIds <- dplyr::select(outcomes, "rowId") %>% dplyr::pull()
+    covariates <- covariates %>% dplyr::filter(.data$rowId %in% outcomeRowIds)
+    covariates <- covariates %>% dplyr::arrange(.data$covariateId, .data$rowId)
+    Andromeda::batchApply(covariates, fn)
+    return(invisible(NULL))
+  }
+  
+  convertData(andr$covariates, andr$outcomes)
+  Andromeda::close(andr)
+  
+  expect_true(!dir.exists(attr(andr, "path")))
+  
+})


### PR DESCRIPTION
Added a test that is currently failing for me most of the time on windows because for some reason a file lock is introduced when using batchApply. 

One weird thing, when pressing "test" on the test file in the rstudio GUI it always passes. But when running either ```testthat::test_file('./tests/test-filelocks.R')``` or ```devtools::test()``` it fails most of the time. I'm curious to see what happens with github actions.

I think this issue can be fixed by using the new ```.unsafe_delete()``` method (as a last resort) from Arrow 11. 

@ablack3 wasn't sure if this test belongs in the same files as some other tests so I created a new file. Happy to change.