### PR TITLE
Issue 53

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
   pillar,
   glue,
   tidyselect,
-  jsonlite,
   ParallelLogger
 Suggests:
   testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ Suggests:
   DBI
 LazyData: false
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
   pillar,
   glue,
   tidyselect,
-  jsonlite
+  jsonlite,
+  ParallelLogger
 Suggests:
   testthat,
   dbplyr,

--- a/R/LoadingSaving.R
+++ b/R/LoadingSaving.R
@@ -63,7 +63,8 @@ saveAndromeda <- function(andromeda, fileName, overwrite = TRUE) {
   attribs <- attributes(andromeda)
   attribs[["class"]] <- attribs[["path"]] <- attribs[["names"]] <- attribs[["env"]] <- attribs[[".xData"]] <- NULL
   attributesFileName <- file.path(tempdir(), "user-defined-attributes.json")
-  jsonlite::write_json(attribs, attributesFileName)
+  ParallelLogger::saveSettingsToJson(attribs, attributesFileName)
+  # jsonlite::write_json(attribs, attributesFileName, pretty = TRUE, force = TRUE, null = "null", auto_unbox = TRUE)
   
   tableDirs <- list.dirs(attr(andromeda, "path"), recursive = FALSE)
   zip::zipr(fileName, c(attributesFileName, tableDirs), compression_level = 2)
@@ -115,7 +116,8 @@ loadAndromeda <- function(fileName) {
   }
   class(andr) <- andrClass
   
-  attributes <- jsonlite::read_json(file.path(path, "user-defined-attributes.json"), simplifyVector = TRUE)
+  attributes <- ParallelLogger::loadSettingsFromJson(file.path(path, "user-defined-attributes.json"))
+  # attributes <- jsonlite::read_json(file.path(path, "user-defined-attributes.json"), simplifyVector = TRUE)
   on.exit(unlink(file.path(path, "user-defined-attributes.json")))
   for (nm in names(attributes)) {
     attr(andr, nm) <- attributes[[nm]]

--- a/man/batchApply.Rd
+++ b/man/batchApply.Rd
@@ -4,7 +4,7 @@
 \alias{batchApply}
 \title{Apply a function to batches of data in an Andromeda table}
 \usage{
-batchApply(tbl, fun, ..., batchSize = 1e+05, progressBar = FALSE, safe = FALSE)
+batchApply(tbl, fun, ..., batchSize, progressBar = FALSE, safe = FALSE)
 }
 \arguments{
 \item{tbl}{An \code{\link{Andromeda}} table (or any other 'DBI' table).}
@@ -13,7 +13,7 @@ batchApply(tbl, fun, ..., batchSize = 1e+05, progressBar = FALSE, safe = FALSE)
 
 \item{...}{Additional parameters passed to fun.}
 
-\item{batchSize}{Number of rows to fetch at a time.}
+\item{batchSize}{DEPRECATED: Number of rows to fetch at a time.}
 
 \item{progressBar}{Show a progress bar?}
 
@@ -40,7 +40,7 @@ fun <- function(x) {
   return(nrow(x))
 }
 
-result <- batchApply(andr$cars, fun, batchSize = 25)
+result <- batchApply(andr$cars, fun)
 
 result
 # [[1]]

--- a/man/groupApply.Rd
+++ b/man/groupApply.Rd
@@ -9,7 +9,7 @@ groupApply(
   groupVariable,
   fun,
   ...,
-  batchSize = 1e+05,
+  batchSize,
   progressBar = FALSE,
   safe = FALSE
 )
@@ -23,7 +23,7 @@ groupApply(
 
 \item{...}{Additional parameters passed to fun.}
 
-\item{batchSize}{Number of rows fetched from the table at a time. This is not the number of
+\item{batchSize}{DEPRECATED: Number of rows fetched from the table at a time. This is not the number of
 rows to which the function will be applied. Included mostly for testing
 purposes.}
 

--- a/tests/testthat/test-batching.R
+++ b/tests/testthat/test-batching.R
@@ -8,19 +8,19 @@ test_that("batchApply", {
     return(nrow(batch) * multiplier)
   }
   
-  result <- batchApply(andromeda$cars, doSomething, multiplier = 2, batchSize = 10)
+  result <- batchApply(andromeda$cars, doSomething, multiplier = 2)
   result <- unlist(result)
   expect_true(sum(result) == nrow(cars) * 2)
-  expect_true(length(result) == ceiling(nrow(cars)/10))
+  # expect_true(length(result) == ceiling(nrow(cars)/10))
   rm(result)
   
   # batchApply can also accept an arrow_dplyr_query
   query <- dplyr::mutate(andromeda$cars, new_column = speed*dist)
   expect_s3_class(query, "arrow_dplyr_query")
-  result <- query %>% batchApply(doSomething, multiplier = 2, batchSize = 10)
+  result <- query %>% batchApply(doSomething, multiplier = 2)
   result <- unlist(result)
   expect_true(sum(result) == nrow(cars) * 2)
-  expect_true(length(result) == ceiling(nrow(cars)/10))
+  # expect_true(length(result) == ceiling(nrow(cars)/10))
   
   close(andromeda)
 })
@@ -37,7 +37,7 @@ test_that("batchApply safe mode", {
       appendToTable(andromeda$cars2, batch)
     }
   }
-  batchApply(andromeda$cars, doSomething, multiplier = 2, batchSize = 10, safe = TRUE)
+  batchApply(andromeda$cars, doSomething, multiplier = 2, safe = TRUE)
 
   cars2 <- andromeda$cars2 %>% collect() %>% arrange(speed, dist)
   cars1 <- cars %>% arrange(speed, dist)
@@ -54,8 +54,8 @@ test_that("batchApply progress bar", {
   doSomething <- function(batch, multiplier) {
     return(nrow(batch) * multiplier)
   }
-  result <- capture_output(batchApply(andromeda$cars, doSomething, multiplier = 2, batchSize = 10, progressBar = TRUE))
-  expect_true(stringr::str_count(result, "=") > 100)
+  result <- capture_output(batchApply(andromeda$cars, doSomething, multiplier = 2, progressBar = TRUE))
+  expect_true(grepl("100%", result))
   close(andromeda)
 })
 
@@ -81,8 +81,8 @@ test_that("groupApply progress bar", {
   doSomething <- function(batch, multiplier) {
     return(nrow(batch) * multiplier)
   }
-  result <- capture_output(groupApply(andromeda$cars, "speed", doSomething, multiplier = 2, batchSize = 10, progressBar = TRUE))
-  expect_true(stringr::str_count(result, "=") > 100)
+  result <- capture_output(groupApply(andromeda$cars, "speed", doSomething, multiplier = 2, progressBar = TRUE))
+  expect_true(grepl("100%", result))
   close(andromeda)
 })
 

--- a/tests/testthat/test-loadingSaving.R
+++ b/tests/testthat/test-loadingSaving.R
@@ -8,7 +8,9 @@ test_that("Saving and loading", {
   expect_true("table" %in% names(andromeda))
   iris1 <- andromeda$table %>% collect()
 
-  attr(andromeda, "metaData") <- list(x = 1)
+  s3Object <- list(a = 1)
+  class(s3Object) <- "MyClass"
+  attr(andromeda, "metaData") <- list(x = 1, y = list(s3Object))
 
   fileName <- tempfile(fileext = ".zip")
   fileName <- file.path(.getAndromedaTempFolder(), "asdf.zip")
@@ -27,6 +29,7 @@ test_that("Saving and loading", {
   expect_equivalent(iris1, iris2)
   expect_false(is.null(attr(andromeda2, "metaData")))
   expect_equal(attr(andromeda2, "metaData")$x, 1)
+  expect_equal(class(attr(andromeda2, "metaData")$y[[1]]), "MyClass")
 
   expect_error(capture.output(saveAndromeda(andromeda2, fileName, overwrite = TRUE)), NA)
 


### PR DESCRIPTION
This uses `as_record_batch_reader()`, thus avoiding the need to copy a dplyr query to an Andromeda object. Addresses issue #53 .

Note: this PR also includes the changes of PR https://github.com/OHDSI/Andromeda/pull/55 (allowing me to test both locally).