### PR TITLE
Duckdb assign and copy improvements

### DIFF
--- a/R/Object.R
+++ b/R/Object.R
@@ -139,13 +139,13 @@ copyAndromeda <- function(andromeda, options = list()) {
   for (table in tables) {
     DBI::dbExecute(newAndromeda, sprintf("CREATE TABLE %s AS SELECT * FROM old.%s", table, table))
   }
-  DBI::dbExecute(newAndromeda, "DETACH DATABASE old")
   if (!dplyr::setequal(names(andromeda), names(newAndromeda))) {
     succeeded <- paste(dplyr::intersect(names(andromeda), names(newAndromeda)), collapse = ", ")
     failed <- paste(dplyr::setdiff(names(andromeda), names(newAndromeda)), collapse = ", ")
     msg <- paste("Error copying Andromeda object.\n", succeeded, "copied successfully.\n", failed, "failed to copy.\n")
     rlang::abort(msg)
   } 
+  DBI::dbExecute(newAndromeda, "DETACH DATABASE old")
   return(newAndromeda)
 }
 
@@ -266,7 +266,7 @@ setMethod("[[<-", "Andromeda", function(x, i, value) {
       if (duckdb::dbExistsTable(x, i)) {
         duckdb::dbRemoveTable(x, i)
       }
-      valueSourceFile <- dbplyr::remote_con(value)@driver@dbdir
+      valueSourceFile <- dbplyr::remote_con(value)@dbname
       sourceTableName <- dbplyr::remote_name(value)
       if (is.null(sourceTableName)) {
         # value is a lazy_query compute first to a temp parquet file

--- a/R/Object.R
+++ b/R/Object.R
@@ -152,6 +152,7 @@ copyAndromeda <- function(andromeda, options = list()) {
 # By default .createAndromeda will create a new duckdb instance in a temp folder. However it can also use an existing duckdb file.
 .createAndromeda <- function(dbdir = tempfile(tmpdir = .getAndromedaTempFolder(), fileext = ".duckdb"), options = list()) {
   andromeda <- duckdb::dbConnect(duckdb::duckdb(), dbdir = dbdir)
+  DBI::dbExecute(andromeda, "SET wal_autocheckpoint = '0KB'")
   class(andromeda) <- "Andromeda"
   attr(class(andromeda), "package") <- "Andromeda"
   andromeda@dbname <- andromeda@driver@dbdir

--- a/R/Object.R
+++ b/R/Object.R
@@ -269,8 +269,9 @@ setMethod("[[<-", "Andromeda", function(x, i, value) {
       }
       valueSourceFile <- dbplyr::remote_con(value)@dbname
       sourceTableName <- dbplyr::remote_name(value)
-      if (is.null(sourceTableName)) {
-        # value is a lazy_query compute first to a temp parquet file
+      if (is.null(sourceTableName) || .Platform$OS.type == "windows") {
+        # value is a lazy_query or windows which has strong file locks and can't attach
+        # compute first to a temp parquet file
         tempFile <- tempfile(tmpdir = .getAndromedaTempFolder(),
                              fileext = ".parquet")
         DBI::dbExecute(

--- a/R/Object.R
+++ b/R/Object.R
@@ -247,7 +247,7 @@ setMethod("[[<-", "Andromeda", function(x, i, value) {
     duckdb::dbWriteTable(conn = x, name = i, value = value, overwrite = TRUE, append = FALSE)
   } else if (inherits(value, "tbl_dbi")) {
     .checkAvailableSpace(x)
-    if (isTRUE(all.equal(x, dbplyr::remote_con(value)))) {
+    if (identical(x, dbplyr::remote_con(value))) {
       # x[[i]] and value are tables are in the same Andromeda object
       sql <- dbplyr::sql_render(value, x)
       if (duckdb::dbExistsTable(x, i)) {

--- a/R/Operations.R
+++ b/R/Operations.R
@@ -232,7 +232,7 @@ appendToTable <- function(tbl, data) {
                          overwrite = FALSE,
                          append = TRUE)
   } else if (inherits(data, "tbl_dbi")) {
-    if (isTRUE(all.equal(connection, dbplyr::remote_con(data)))) {
+    if (identical(connection, dbplyr::remote_con(data))) {
       sql <- dbplyr::sql_render(select(data, all_of(colnames(tbl))), connection)
       sql <- sprintf("INSERT INTO %s %s", tableName, sql)
       DBI::dbExecute(connection, sql)

--- a/tests/testthat/test-loadingSaving.R
+++ b/tests/testthat/test-loadingSaving.R
@@ -2,9 +2,9 @@ library(testthat)
 
 test_that("Saving and loading", {
   andromeda <- andromeda()
-  andromeda$table <- iris
-  expect_true("table" %in% names(andromeda))
-  iris1 <- andromeda$table %>% collect()
+  andromeda$iris <- iris
+  expect_true("iris" %in% names(andromeda))
+  iris1 <- andromeda$iris %>% collect()
 
   attr(andromeda, "metaData") <- list(x = 1)
 
@@ -22,9 +22,9 @@ test_that("Saving and loading", {
   expect_error(saveAndromeda(andromeda, fileName, overwrite = FALSE), "already exists")
 
   expect_error(andromeda2 <- loadAndromeda(fileName), NA)
-  expect_true("table" %in% names(andromeda2))
+  expect_true("iris" %in% names(andromeda2))
 
-  iris2 <- andromeda2$table %>% collect()
+  iris2 <- andromeda2$iris %>% collect()
 
   expect_equivalent(iris1, iris2)
   expect_false(is.null(attr(andromeda, "metaData")))


### PR DESCRIPTION
Fixes #73 

* Use `attach` and `copy` operations instead of `batchApply` in `copyAndromeda` and assignment ( `"[[<-" `)
  * On windows attach won't work because of file lock (even if from same process), so write to temp parquet instead

* In "[[<-" attach/copy didn't work for `lazy_queries`: materialize query to parquet file and then assign into database

* Use `identical` instead of `all.equal`, it's faster and more fit for purpose.

* Set `"wal_autocheckpoint = '0KB'"` to immediately commit changes to the database instead of having them in the wal file. Had an issue with this in `deepPlp` and this seems to match the previous behaviour which [disabled](https://github.com/OHDSI/Andromeda/blob/main/R/Object.R#L143) `journal_mode` for sqlite 

* Had to modify one test because `table` is a reserved word in `duckdb` so the test failed. Renamed the `table` to `iris`.

<details>
  <summary> Microbenchmark reprex for identical vs all.equal </summary>

```R
library(Andromeda)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

obj <- andromeda(data = iris)

microbenchmark::microbenchmark(identical(obj, obj),
  all.equal(obj, obj),
  times = 100
)
#> Unit: microseconds
#>                 expr       min        lq        mean     median         uq
#>  identical(obj, obj)     1.251     1.567     2.80481     2.8225     3.9325
#>  all.equal(obj, obj) 21549.433 21927.425 22786.16796 22256.6920 23514.7060
#>        max neval
#>      7.853   100
#>  27373.431   100
```

<sup>Created on 2025-02-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
</details>

<details>
  <summary> Microbenchmark reprex for attach method vs `batchApply` for `[[<-` </summary>

``` r
library(Andromeda)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
andromeda <- andromeda()
n <- 16e5
n_subjects <- 100e3
n_cols <- 5e3

covariates <- data.frame(
  row = sample(1:n_subjects, n, replace = TRUE),
  col = sample(1:n_cols, n, replace = TRUE),
  c = rnorm(n)
)
covariateRef <- data.frame(
  a = 1:3e3,
  b = letters[1:3e3],
  c = rnorm(3e3)
)
analysisRef <- data.frame(
  a = 1:3e1,
  b = letters[1:3e1],
  c = rnorm(3e1)
)
andromeda$covariates <- covariates
andromeda$covariateRef <- covariateRef
andromeda$analysisRef <- analysisRef 


newAndromeda <- Andromeda::andromeda()
value <- andromeda$covariates

oldWay <- function() {
  doBatchedAppend <- function(batch) {
    duckdb::dbWriteTable(conn = newAndromeda, name = "old", value = batch, overwrite = FALSE, append = TRUE)
    return(TRUE)
  }
  
  dummy <- batchApply(value, doBatchedAppend)
  if (length(dummy) == 0) {
    duckdb::dbWriteTable(conn = newAndromeda, name = "old", value = dplyr::collect(value), overwrite = FALSE, append = TRUE)
  }
}

newWay <- function() {
  valueFile <- dbplyr::remote_con(value)@dbname
  DBI::dbExecute(newAndromeda, paste0("ATTACH DATABASE '", valueFile, "' AS old"))
  DBI::dbExecute(newAndromeda, paste0("CREATE TABLE new AS SELECT * FROM old.covariates"))
  DBI::dbExecute(newAndromeda, "DETACH DATABASE old")
}

microbenchmark::microbenchmark(oldWay(),
                               newWay(), times = 10,
                               setup = {
                                 newAndromeda$old <- NULL
                                 newAndromeda$new <- NULL
                                 }
                               )
#> Unit: milliseconds
#>      expr       min        lq      mean   median        uq       max neval
#>  oldWay() 786.22978 804.82203 837.65396 850.4561 862.61454 875.71107    10
#>  newWay()  30.72729  32.49021  33.92148  34.3015  35.16244  35.81522    10
```

<sup>Created on 2025-02-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
</details>
